### PR TITLE
Add missing library dependencies

### DIFF
--- a/larevt/CalData/CMakeLists.txt
+++ b/larevt/CalData/CMakeLists.txt
@@ -7,9 +7,9 @@ simple_plugin(CalWireAna "module"
               ${ART_ROOT_IO_TFILESERVICE_SERVICE}
               ${ART_ROOT_IO_TFILE_SUPPORT}
 	      ${MF_MESSAGELOGGER}
-              ${ROOT_CORE}
-              ${ROOT_HIST}
-              ${ROOT_MATHCORE})
+              ROOT::Core
+              ROOT::Hist
+              ROOT::MathCore)
 
 simple_plugin(CalWire "module"
               larcorealg_Geometry
@@ -17,10 +17,10 @@ simple_plugin(CalWire "module"
               lardata_ArtDataHelper
               ${ART_FRAMEWORK_SERVICES_REGISTRY}
               ${MF_MESSAGELOGGER}
-              ${ROOT_CORE}
-              ${ROOT_HIST}
-              ${ROOT_MATHCORE}
-              ${ROOT_RIO})
+              ROOT::Core
+              ROOT::Hist
+              ROOT::MathCore
+              ROOT::RIO)
 
 simple_plugin(CalWireT962 "module"
               larcorealg_Geometry
@@ -28,10 +28,10 @@ simple_plugin(CalWireT962 "module"
               lardata_ArtDataHelper
               ${ART_FRAMEWORK_SERVICES_REGISTRY}
               ${MF_MESSAGELOGGER}
-              ${ROOT_CORE}
-              ${ROOT_HIST}
-              ${ROOT_MATHCORE}
-              ${ROOT_RIO})
+              ROOT::Core
+              ROOT::Hist
+              ROOT::MathCore
+              ROOT::RIO)
 
 install_headers()
 install_fhicl()

--- a/larevt/CalData/test/CMakeLists.txt
+++ b/larevt/CalData/test/CMakeLists.txt
@@ -3,18 +3,18 @@ cet_enable_asserts()
 simple_plugin(FFTTest "module"
 			lardata_Utilities_LArFFT_service
 			${ART_FRAMEWORK_SERVICES_REGISTRY}
-			${ART_ROOT_IO_TFILE_SUPPORT} ${ROOT_CORE}
+			${ART_ROOT_IO_TFILE_SUPPORT} ROOT::Core
 			${ART_ROOT_IO_TFILESERVICE_SERVICE}
 			art_Persistency_Common
 			art_Persistency_Provenance
 	 		art_Utilities
                         canvas
 			${MF_MESSAGELOGGER}
-			
+
 	                ${FHICLCPP}
 			cetlib cetlib_except
 			${ROOT_BASIC_LIB_LIST}
-              
+
 )
 
 install_headers()

--- a/larevt/CalibrationDBI/Providers/CMakeLists.txt
+++ b/larevt/CalibrationDBI/Providers/CMakeLists.txt
@@ -12,7 +12,8 @@ art_make(LIB_LIBRARIES
            cetlib_except
            larcorealg_Geometry
            ${ART_FRAMEWORK_SERVICES_REGISTRY}
-           ${ROOT_CORE}
+           ROOT::Core
+           ${ART_UTILITIES}
         )
 
 install_headers()

--- a/larevt/Filters/CMakeLists.txt
+++ b/larevt/Filters/CMakeLists.txt
@@ -12,16 +12,16 @@ art_make(LIB_LIBRARIES
            ${ART_ROOT_IO_TFILESERVICE_SERVICE}
            ${ART_ROOT_IO_TFILE_SUPPORT}
            ${MF_MESSAGELOGGER}
-           ${ROOT_CORE}
-           ${ROOT_HIST}
-           ${ROOT_PHYSICS}
+           ROOT::Core
+           ROOT::Hist
+           ROOT::Physics
            larcorealg_Geometry
            lardataobj_RawData
            nusimdata_SimulationBase
          SERVICE_LIBRARIES
            larevt_Filters
            ${MF_MESSAGELOGGER}
-           ${ROOT_CORE}
+           ROOT::Core
          )
 
 install_headers()

--- a/larevt/SpaceCharge/CMakeLists.txt
+++ b/larevt/SpaceCharge/CMakeLists.txt
@@ -2,9 +2,9 @@ art_make(NO_PLUGINS
          LIB_LIBRARIES
            canvas
            ${FHICLCPP}
-           ${ROOT_CORE}
-           ${ROOT_HIST}
-           ${ROOT_RIO}
+           ROOT::Core
+           ROOT::Hist
+           ROOT::RIO
            cetlib
            cetlib_except
          )

--- a/larevt/SpaceChargeServices/CMakeLists.txt
+++ b/larevt/SpaceChargeServices/CMakeLists.txt
@@ -1,7 +1,7 @@
 simple_plugin(SpaceChargeServiceStandard "service"
               larevt_SpaceCharge
               ${ART_FRAMEWORK_PRINCIPAL}
-              ${ROOT_CORE}
+              ROOT::Core
             )
 
 install_headers()


### PR DESCRIPTION
Also change to ROOT target-based dependencies.

This is part of a coordinated set of PRs that accomplish two tasks:

- Switching to geometry collections that own by value instead of by pointer
- Switching the (AuxDet) geometry systems to be thread-safe within a run

There are breaking changes associated with this PR, and they will be presented at the next LArSoft coordination meeting.