### PR TITLE
move mutex outside of if

### DIFF
--- a/larevt/CalibrationDBI/Providers/DetPedestalRetrievalAlg.cxx
+++ b/larevt/CalibrationDBI/Providers/DetPedestalRetrievalAlg.cxx
@@ -169,12 +169,12 @@ namespace lariov {
   bool DetPedestalRetrievalAlg::DBUpdate(DBTimeStamp_t ts) const
   {
 
+    // A static mutex that is shared across all invocations of the function.
+    static std::mutex mutex;
+    std::lock_guard<std::mutex> lock(mutex);
+
     bool result = false;
     if (fDataSource == DataSource::Database && ts != fCurrentTimeStamp) {
-
-      // A static mutex that is shared across all invocations of the function.
-      static std::mutex mutex;
-      std::lock_guard<std::mutex> lock(mutex);
 
       mf::LogInfo("DetPedestalRetrievalAlg")
         << "DetPedestalRetrievalAlg::DBUpdate called with new timestamp.";

--- a/larevt/CalibrationDBI/Providers/SIOVChannelStatusProvider.cxx
+++ b/larevt/CalibrationDBI/Providers/SIOVChannelStatusProvider.cxx
@@ -102,12 +102,12 @@ namespace lariov {
   bool SIOVChannelStatusProvider::DBUpdate(DBTimeStamp_t ts) const
   {
 
+    // A static mutex that is shared across all invocations of the function.
+    static std::mutex mutex;
+    std::lock_guard<std::mutex> lock(mutex);
+
     bool result = false;
     if (fDataSource == DataSource::Database && ts != fCurrentTimeStamp) {
-
-      // A static mutex that is shared across all invocations of the function.
-      static std::mutex mutex;
-      std::lock_guard<std::mutex> lock(mutex);
 
       mf::LogInfo("SIOVChannelStatusProvider")
         << "SIOVChannelStatusProvider::DBUpdate called with new timestamp.";


### PR DESCRIPTION
This is a bug fix.
The issue is that, since `fCurrentTimeStamp = ts;` is within the `if (fDataSource == DataSource::Database && ts != fCurrentTimeStamp) {`, at the beginning of an event multiple threads could satisfy the `if` condition. So while the 1st one goes through the mutex, the others wait. Then at some point the next thread follows and calls `fData.Clear();` from within the `if` which becomes a race condition for the 1st thread that has already moved along. This eventually causes an exception to be thrown as a valid channel number is not found in `fData`.